### PR TITLE
[Feat] 검색 결과에 date 정보 추가

### DIFF
--- a/src/main/java/com/artique/api/search/dto/SearchMusicalDto.java
+++ b/src/main/java/com/artique/api/search/dto/SearchMusicalDto.java
@@ -4,6 +4,11 @@ import com.artique.api.entity.Musical;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.logging.log4j.util.StringBuilders;
+
+import javax.swing.text.DateFormatter;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -12,8 +17,13 @@ public class SearchMusicalDto {
   private String musicalId;
   private String posterUrl;
   private String title;
+  private String duration;
 
   public static SearchMusicalDto of(Musical m){
-    return new SearchMusicalDto(m.getId(),m.getPosterUrl(),m.getName());
+    DateTimeFormatter dateformat = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    String beginDate = m.getBeginDate().format(dateformat);
+    String endDate = m.getEndDate().format(dateformat);
+    String duration = beginDate + " ~ " + endDate;
+    return new SearchMusicalDto(m.getId(),m.getPosterUrl(),m.getName(), duration);
   }
 }


### PR DESCRIPTION
기존 search/detail api response
```
{
    "musicals": [
        {
            "musicalId": "PF144565",
            "posterUrl": "http://www.kopis.or.kr/upload/pfmPoster/PF_PF144565_220811_114818.jpg",
            "title": "아기돼지삼형제: 늑대숲 또옹돼지 원정대"
        }
    ],
    "size": 1
}
```

바뀐 reponse 정보 (date 정보 String 형태로 추가)
```
{
    "musicals": [
        {
            "musicalId": "PF144565",
            "posterUrl": "http://www.kopis.or.kr/upload/pfmPoster/PF_PF144565_220811_114818.jpg",
            "title": "아기돼지삼형제: 늑대숲 또옹돼지 원정대",
            "duration": "2018-04-07 ~ 2023-08-27"
        }
    ],
    "size": 1
}
```