### PR TITLE
[Fix] interceptor에서 home 관련 api는 인증 제외

### DIFF
--- a/src/main/java/com/artique/api/config/WebMvcConfig.java
+++ b/src/main/java/com/artique/api/config/WebMvcConfig.java
@@ -54,7 +54,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
   }
   public String[] buildExcludePattern(){
     String[] excludePatternsForUri = {"/member/**","/feed/**","/review/**","/musical/**","/search/**",
-            "/config/**","/session/**"};
+            "/config/**","/session/**","/home/**"};
     List<String> patterns = new ArrayList<>();
     patterns.addAll(Arrays.asList(excludePatternsForStaticResource));
     patterns.addAll(Arrays.asList(excludePatternsForUri));


### PR DESCRIPTION
1. 인터셉터에서 리뉴얼한 홈 관련 api는 인증에서 제외